### PR TITLE
Make error handling more go idiomatic

### DIFF
--- a/cmd/ts-dump/main.go
+++ b/cmd/ts-dump/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"log"
 
 	"github.com/timescale/ts-dump-restore/pkg/dump"
 	"github.com/timescale/ts-dump-restore/pkg/util"
@@ -9,8 +10,15 @@ import (
 
 func main() {
 	config := &util.Config{}
-	util.RegisterConfigFlags(config)
+	config = util.RegisterConfigFlags(config)
+
 	flag.Parse()
-	util.CleanConfig(config)
-	dump.DoDump(config)
+	config, err := util.CleanConfig(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = dump.DoDump(config)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/ts-restore/main.go
+++ b/cmd/ts-restore/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"log"
 
 	"github.com/timescale/ts-dump-restore/pkg/restore"
 	"github.com/timescale/ts-dump-restore/pkg/util"
@@ -9,8 +10,15 @@ import (
 
 func main() {
 	config := &util.Config{}
-	util.RegisterConfigFlags(config)
+	config = util.RegisterConfigFlags(config)
+
 	flag.Parse()
-	util.CleanConfig(config)
-	restore.DoRestore(config)
+	config, err := util.CleanConfig(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = restore.DoRestore(config)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -3,8 +3,8 @@ package dump
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 
@@ -13,29 +13,29 @@ import (
 )
 
 // DoDump takes a config and performs a database dump
-func DoDump(cf *util.Config) {
+func DoDump(cf *util.Config) error {
 	dumpPath, err := exec.LookPath("pg_dump")
 	if err != nil {
-		log.Fatalf("could not find pg_dump")
+		return errors.New("pg_dump not found, please make sure it is installed")
 	}
 	getver := exec.Command(dumpPath, "--version")
 	out, err := getver.CombinedOutput()
 	if err != nil {
-		log.Fatalf("Failed to get version of pg_dump: %s\n", err)
+		return fmt.Errorf("failed to get version of pg_dump: %w", err)
 	}
 	fmt.Printf("pg_dump version: %s\n", string(out))
 
 	file, err := createInfoFile(cf)
 	if err != nil {
-		log.Fatalf("Error with dump file creation: %s\n", err)
+		return fmt.Errorf("error with dump file creation: %w", err)
 	}
 	defer file.Close()
 
-	tsInfo := getTimescaleInfo(cf.DbURI)
+	tsInfo, err := getTimescaleInfo(cf.DbURI)
 	encoder := json.NewEncoder(file)
 	err = encoder.Encode(&tsInfo)
 	if err != nil {
-		log.Fatalf("Error writing timescale infor %v", err)
+		return fmt.Errorf("Error writing timescale info %w", err)
 	}
 
 	dump := exec.Command(dumpPath)
@@ -47,9 +47,9 @@ func DoDump(cf *util.Config) {
 	dump.Stderr = os.Stderr
 	err = dump.Run()
 	if err != nil {
-		log.Fatalf("pg_dump run failed with: %s\n", err)
+		return fmt.Errorf("pg_dump run failed with: %w", err)
 	}
-	return
+	return err
 }
 
 func createInfoFile(cf *util.Config) (*os.File, error) {
@@ -63,17 +63,21 @@ func createInfoFile(cf *util.Config) (*os.File, error) {
 	return file, err
 }
 
-func getTimescaleInfo(dbURI string) util.TsInfo {
-	conn := util.GetDBConn(context.Background(), dbURI)
+func getTimescaleInfo(dbURI string) (util.TsInfo, error) {
+	info := util.TsInfo{}
+
+	conn, err := util.GetDBConn(context.Background(), dbURI)
+	if err != nil {
+		return info, err
+	}
 	defer conn.Close(context.Background())
 
-	info := util.TsInfo{}
-	err := conn.QueryRow(context.Background(), "SELECT e.extversion,  n.nspname FROM pg_extension e INNER JOIN pg_namespace n ON e.extnamespace = n.oid WHERE e.extname='timescaledb'").Scan(&info.TsVersion, &info.TsSchema)
+	err = conn.QueryRow(context.Background(), "SELECT e.extversion,  n.nspname FROM pg_extension e INNER JOIN pg_namespace n ON e.extnamespace = n.oid WHERE e.extname='timescaledb'").Scan(&info.TsVersion, &info.TsSchema)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			log.Fatal("TimescaleDB extension not found, is it installed in the database you are dumping?")
+			return info, errors.New("TimescaleDB extension not found, make sure it is installed in the database being dumped")
 		}
-		log.Fatal(err)
+		return info, err
 	}
-	return info
+	return info, err
 }


### PR DESCRIPTION
Error handling should be passed mostly up to the main function,
this uses the fmt.Errorf and errors.New to pass up errors so
that deferred function calls etc are executed properly.