### PR TITLE
Add timestamp to logs

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -52,9 +52,7 @@ func DoDump(cf *util.Config) error {
 	if cf.Jobs > 0 {
 		dump.Args = append(dump.Args, fmt.Sprintf("--jobs=%d", cf.Jobs))
 	}
-	dump.Stdout = os.Stdout
-	dump.Stderr = os.Stderr
-	err = dump.Run()
+	err = util.RunCommandAndFilterOutput(dump, os.Stdout, os.Stderr, true)
 	if err != nil {
 		return fmt.Errorf("pg_dump run failed with: %w", err)
 	}


### PR DESCRIPTION
Prepend a timestamp to log lines, also moves the run and filter output
functionality into the util package as it's now shared between dump and
restore. We might also use that for further filtering in dumps later.