### PR TITLE
Update go.mod with real name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/timescale/ts-dump-restore
+module github.com/timescale/timescaledb-backup
 
 go 1.14
 


### PR DESCRIPTION
fixes #29  updates module name to timescaledb-backup and points at the right place.