### PR TITLE
Remove single txn flag for pre-data restore

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -66,7 +66,7 @@ func DoRestore(cf *util.Config) error {
 		baseArgs = append(baseArgs, "--verbose")
 	}
 	// Now just the pre-data section
-	restore := getRestoreCmd(restorePath, cf.PgDumpDir, baseArgs, "--section=pre-data", "--single-transaction")
+	restore := getRestoreCmd(restorePath, cf.PgDumpDir, baseArgs, "--section=pre-data")
 	err = util.RunCommandAndFilterOutput(restore, os.Stdout, os.Stderr, true)
 	if err != nil {
 		return fmt.Errorf("pg_restore run failed in pre-data section: %w", err)


### PR DESCRIPTION
The single transaction flag on the pre-data portion of the restore had the potential to cause odd locking issues, though it's unclear whether this will completely alleviate them, I don't think it was actually adding much safety. So this should be fine.