### PR TITLE
Fix errors on TOC writing

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -135,7 +135,11 @@ func makeRestoreTOC(restorePath string, dumpDir string, TOCFile *os.File) error 
 	restore.Args = append(restore.Args, dumpDir)
 	restore.Args = append(restore.Args, "--list")
 	TOCWriter := bufio.NewWriter(TOCFile)
-	return util.RunCommandAndFilterOutput(restore, TOCWriter, os.Stderr, false, "COMMENT - EXTENSION timescaledb")
+	err := util.RunCommandAndFilterOutput(restore, TOCWriter, os.Stderr, false, "COMMENT - EXTENSION timescaledb")
+	if err != nil {
+		return err
+	}
+	return TOCWriter.Flush()
 }
 
 func getRestoreVersion() (string, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -125,7 +125,6 @@ func CreateTimescaleAtVer(dbContext context.Context, dbURI string, targetSchema 
 func RunCommandAndFilterOutput(cmd *exec.Cmd, stdout io.Writer, stderr io.Writer, prependTime bool, filters ...string) error {
 	stdoutIn, _ := cmd.StdoutPipe()
 	stderrIn, _ := cmd.StderrPipe()
-
 	err := cmd.Start()
 	if err != nil {
 		return fmt.Errorf("cmd.Start() failed with '%w'", err)
@@ -158,6 +157,10 @@ func writeAndFilterOutput(readIn io.Reader, scanOut io.Writer, prependTime bool,
 	scanIn := bufio.NewScanner(readIn)
 	var err error
 	for scanIn.Scan() {
+		err = scanIn.Err()
+		if err != nil {
+			return err
+		}
 		stringMatch := false
 
 		for _, filter := range filters {


### PR DESCRIPTION
Buffered output wasn't being correctly flushed and we weren't checking
scanIn for errors.

Fixes #35 